### PR TITLE
Use correct aggregation names for Grafana

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vonage-status-panel",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vonage-status-panel",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "11.10.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vonage-status-panel",
   "private": true,
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Status Panel for Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/lib/statusMigrationHandler.ts
+++ b/src/lib/statusMigrationHandler.ts
@@ -35,6 +35,16 @@ interface AngularPanelModel extends Omit<PanelModel, 'targets'> {
   ];
 }
 
+const aggregationMigrationMap = {
+  Last: 'last',
+  First: 'first',
+  Max: 'max',
+  Min: 'min',
+  Sum: 'sum',
+  Avg: 'mean',
+  Delta: 'delta',
+};
+
 const isAngularModel = (panel: Omit<PanelModel, 'targets'>): panel is AngularPanelModel =>
   !!panel.options && 'clusterName' in panel;
 
@@ -59,9 +69,14 @@ const migrateFieldConfig = (panel: AngularPanelModel) => {
       };
 
       if (target.aggregation) {
+        let newAggregationName =
+          aggregationMigrationMap[String(target.aggregation) as keyof typeof aggregationMigrationMap];
+        if (newAggregationName?.length === 0) {
+          newAggregationName = String(target.aggregation);
+        }
         fieldConfigOverride.properties.push({
           id: 'custom.aggregation',
-          value: target.aggregation,
+          value: newAggregationName,
         });
       }
 


### PR DESCRIPTION
The existing migration was incorrectly assigning "Avg" instead of "mean" as Grafana now defines it.

The other migrations were correct but captilized and grafana defines them all in lower case
